### PR TITLE
Use texfile for bibtex

### DIFF
--- a/bin/latex-watcher.js
+++ b/bin/latex-watcher.js
@@ -35,12 +35,9 @@ var gaze = require('gaze'),
            .demand('t')
            .alias('t', 'tex')
            .describe('t', 'tex file to compile on changes')
-           .alias('b','bib')
-           .describe('b', 'bib file used (required if bibtex is used)')
            .describe('once', 'only run the commands once (no watching)')
            .default('c', 'pdflatex').argv,
     texName = argv.t,
-    bibName = argv.bib,
     commands = argv.c,
 
     tempFiles = ['.blg','.bbl','.aux','.log','.brf','.nlo','.out','.dvi','.ps',
@@ -94,7 +91,7 @@ var gaze = require('gaze'),
 
     compileBibtex = function(cb){
       process.stdout.write('  » bibtex');
-      var bibtex      = spawn('bibtex', [bibName]);
+      var bibtex      = spawn('bibtex', [texName]);
       bibtex.on('exit', function (code) {
         process.stdout.write((code==0 ? '\r  ✓ bibtex'.green : '\r  × bibtex'.red) + '\n');
         if(cb != undefined) cb();

--- a/bin/latex-watcher.js
+++ b/bin/latex-watcher.js
@@ -71,7 +71,12 @@ var gaze = require('gaze'),
 
     compileLatex = function(cb){
       process.stdout.write('  » latex');
-      var latex      = spawn('latex', ['-interaction=nonstopmode',texName]);
+      var args = ['-interaction=nonstopmode']
+      if (argv.e) {
+        args.push('-shell-escape')
+      }
+      args.push(texName)
+      var latex      = spawn('latex', args);
       latex.on('exit', function (code) {
         process.stdout.write((code==0 ? '\r  ✓ latex'.green : '\r  × latex'.red) + '\n');
         if(code != 0){
@@ -98,7 +103,12 @@ var gaze = require('gaze'),
 
     compileBibtex = function(cb){
       process.stdout.write('  » bibtex');
-      var bibtex      = spawn('bibtex', [texName]);
+      var args = []
+      if (argv.e) {
+        args.push('-shell-escape')
+      }
+      args.push(texName)
+      var bibtex      = spawn('bibtex', args);
       bibtex.on('exit', function (code) {
         process.stdout.write((code==0 ? '\r  ✓ bibtex'.green : '\r  × bibtex'.red) + '\n');
         if(cb != undefined) cb();

--- a/bin/latex-watcher.js
+++ b/bin/latex-watcher.js
@@ -87,7 +87,7 @@ var gaze = require('gaze'),
         args.push('-shell-escape')
       }
       args.push(texName)
-      var pdflatex      = spawn('pdflatex', args]);
+      var pdflatex      = spawn('pdflatex', args);
       pdflatex.on('exit', function (code) {
         process.stdout.write((code==0 ? '\r  ✓ pdflatex'.green : '\r  × pdflatex'.red) + '\n');
         if(code != 0){

--- a/bin/latex-watcher.js
+++ b/bin/latex-watcher.js
@@ -103,12 +103,7 @@ var gaze = require('gaze'),
 
     compileBibtex = function(cb){
       process.stdout.write('  » bibtex');
-      var args = []
-      if (argv.e) {
-        args.push('-shell-escape')
-      }
-      args.push(texName)
-      var bibtex      = spawn('bibtex', args);
+      var bibtex      = spawn('bibtex', [texName]);
       bibtex.on('exit', function (code) {
         process.stdout.write((code==0 ? '\r  ✓ bibtex'.green : '\r  × bibtex'.red) + '\n');
         if(cb != undefined) cb();

--- a/bin/latex-watcher.js
+++ b/bin/latex-watcher.js
@@ -36,9 +36,11 @@ var gaze = require('gaze'),
            .alias('t', 'tex')
            .describe('t', 'tex file to compile on changes')
            .describe('once', 'only run the commands once (no watching)')
+           .describe('shell-escape', 'invoke pdflatex with shell-escape')
+           .alias('e', 'shell-escape')
            .default('c', 'pdflatex').argv,
     texName = argv.t,
-    commands = argv.c,
+    commands = argv.c
 
     tempFiles = ['.blg','.bbl','.aux','.log','.brf','.nlo','.out','.dvi','.ps',
       '.lof','.toc','.fls','.fdb_latexmk','.pdfsync','.synctex.gz','.ind','.ilg','.idx']
@@ -80,7 +82,12 @@ var gaze = require('gaze'),
 
     compilePDFLatex = function(cb){
       process.stdout.write('  » pdflatex');
-      var pdflatex      = spawn('pdflatex', ['-interaction=nonstopmode',texName]);
+      var args = ['-interaction=nonstopmode']
+      if (argv.e) {
+        args.push('-shell-escape')
+      }
+      args.push(texName)
+      var pdflatex      = spawn('pdflatex', args]);
       pdflatex.on('exit', function (code) {
         process.stdout.write((code==0 ? '\r  ✓ pdflatex'.green : '\r  × pdflatex'.red) + '\n');
         if(code != 0){

--- a/bin/latex-watcher.js
+++ b/bin/latex-watcher.js
@@ -38,6 +38,8 @@ var gaze = require('gaze'),
            .describe('once', 'only run the commands once (no watching)')
            .describe('shell-escape', 'invoke pdflatex with shell-escape')
            .alias('e', 'shell-escape')
+           .describe('endings', 'additional filendings to watch')
+           .describe('subfolders', 'additional subfolders to watch')
            .default('c', 'pdflatex').argv,
     texName = argv.t,
     commands = argv.c
@@ -170,10 +172,22 @@ var gaze = require('gaze'),
     };
 
 
-if(!argv.once){
+if(!argv.once) {
   compileAll();
   // Watch all .tex files/dirs in process.cwd()
-  gaze(['**/*.tex', '**/*.bib'], function(err, watcher) {
+
+  var watchEndings = argv.endings ?
+    argv.endings.split(',').map(function(ending) { return '**/*.' + ending }) :
+    [];
+  var watchDirectories = argv.subfolders ? 
+    argv.subfolders.split(',').map(function(subfolder) { return subfolder + '/**/*' }) : 
+    [];
+
+  var watchPaths = ['**/*.tex', '**/*.bib']
+    .concat(watchEndings)
+    .concat(watchDirectories)
+
+  gaze(watchPaths, function(err, watcher) {
     this.on('all', compileAll);
   });
 } else {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     {
       "name": "Mohamed Eltuhamy",
       "email": "tuhamy@gmail.com"
-    } 
+    },
+    {
+      "name": "Nico Ring",
+      "email": "ringnico@web.de"
+    }
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The bibtex command must be called with the main tex file instead of the bibfile, according to the bibtex [documentation](http://www.bibtex.org/Using/). Since the bibfile isn't needed somewhere else, it can be removed completely from the script.
